### PR TITLE
Fix relative path in sendFile()

### DIFF
--- a/server/static.js
+++ b/server/static.js
@@ -76,7 +76,7 @@ module.exports = (app, config) => {
                     if (gzipped)
                         res.set('Content-Encoding', 'gzip');
                     res.set('Content-Disposition', `inline; filename*=UTF-8''${encodeURIComponent(downFileName)}`);
-                    res.sendFile(bookFile);
+                    res.sendFile(path.resolve(bookFile));
                     return;
                 } else {
                     await fs.remove(bookFile);

--- a/server/static.js
+++ b/server/static.js
@@ -39,7 +39,7 @@ module.exports = (app, config) => {
             const fileType = req.params.fileType;
 
             if (path.extname(fileName) === '') {//восстановление файлов {hash}.raw, {hash}.zip
-                let bookFile = `${config.bookDir}/${fileName}`;
+                let bookFile = path.resolve(`${config.bookDir}/${fileName}`);
                 const bookFileDesc = `${bookFile}.d.json`;
 
                 //восстановим из json-файла описания
@@ -76,7 +76,7 @@ module.exports = (app, config) => {
                     if (gzipped)
                         res.set('Content-Encoding', 'gzip');
                     res.set('Content-Disposition', `inline; filename*=UTF-8''${encodeURIComponent(downFileName)}`);
-                    res.sendFile(path.resolve(bookFile));
+                    res.sendFile(bookFile);
                     return;
                 } else {
                     await fs.remove(bookFile);


### PR DESCRIPTION
При использовании относительных путей в `dataDir`, например:

```json
{
    "dataDir": "../.data/.fb2.lib",
}
```
при скачивании книг идут варнинги:
```
ERROR: path must be absolute or specify root to res.sendFile
```
при попытке скачать книгу в `.zip` - 404 ошибка.

Добавил ресолвинг пути в `sendFile()`
